### PR TITLE
Add the option to have persistent switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ switch:
         drive: "PUSH_PULL"
       - name: "Buzzer"
         port: 8
-
+        persistent: true
+        
 # Example of binary_sensor (eg push button) setup
 binary_sensor:
   - platform: gpiod
@@ -106,7 +107,7 @@ Key | Required | Default | Type | Description
 `bias` | no | `AS_IS` | string  | Type of internal pull resistor to use: `PULL_UP` - pull-up resistor, `PULL_DOWN` - pull-down resistor, `AS-IS` no change
 `pull_mode`|*backwards compatibility*| |string|see `bias`, might be removed in the future
 `drive`|no| `PUSH_PULL`|string | control drive configuration of the GPIO, determines how the line behaves when it is set to output mode; `PUSH_PULL`, GPIO line can both source and sink current, can actively drive the line to both high and low states. `OPEN-DRAIN`, GPPIO can only sink current (drive the line to low) and is otherwise left floating, and `OPEN-SOURCE` the reverse.
-
+`persistent` | no | `false` | boolean | If true, the switch state will be persistent in HA and will be restored if HA restart / crash.
 ## Cover
 
 The `gpiod` cover platform allows you to control GPIOs to open/close covers; note that I have only verified cover functionality simulating with switches and buttons, so logic could be off on some points ..

--- a/custom_components/gpiod/hub.py
+++ b/custom_components/gpiod/hub.py
@@ -99,9 +99,6 @@ class Hub:
         if not self._online:
             return
 
-        # setup lines
-        self.update_lines()
-
         # read initial states for sensors
         for port in self._config:
             self._entities[port].update()
@@ -166,6 +163,7 @@ class Hub:
         self._config[port].active_low = active_low
         self._config[port].bias = BIAS[bias]
         self._config[port].drive = DRIVE[drive]
+        self.update_lines()
 
     def turn_on(self, port) -> None:
         _LOGGER.debug(f"in turn_on")
@@ -185,6 +183,7 @@ class Hub:
         self._config[port].edge_detection = Edge.BOTH
         self._config[port].event_clock = Clock.REALTIME
         self._edge_events = True
+        self.update_lines()
 
     def update(self, port, **kwargs):
         return self._lines.get_value(port) == Value.ACTIVE
@@ -194,4 +193,5 @@ class Hub:
         _LOGGER.debug(f"in add_cover {relay_port} {state_port}")
         self.add_switch(entity, relay_port, relay_active_low, relay_bias, relay_drive)
         self.add_sensor(entity, state_port, state_active_low, state_bias, 50)
+        self.update_lines()
 

--- a/custom_components/gpiod/switch.py
+++ b/custom_components/gpiod/switch.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from . import DOMAIN
 
@@ -10,7 +11,8 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.const import CONF_SWITCHES, CONF_NAME, CONF_PORT, CONF_UNIQUE_ID
+from homeassistant.const import CONF_SWITCHES, CONF_NAME, CONF_PORT, CONF_UNIQUE_ID, STATE_ON
+from homeassistant.helpers.restore_state import RestoreEntity
 from .hub import BIAS, DRIVE
 CONF_ACTIVE_LOW ="active_low"
 DEFAULT_ACTIVE_LOW = False
@@ -18,6 +20,9 @@ CONF_BIAS="bias"
 DEFAULT_BIAS = "AS_IS"
 CONF_DRIVE ="drive"
 DEFAULT_DRIVE = "PUSH_PULL"
+CONF_INVERT_LOGIC = "invert_logic"
+CONF_PERSISTENT = "persistent"
+DEFAULT_PERSISTENT = False
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -30,9 +35,10 @@ PLATFORM_SCHEMA = vol.All(
                 vol.Required(CONF_PORT): cv.positive_int,
                 vol.Optional(CONF_UNIQUE_ID): cv.string,
                 vol.Optional(CONF_ACTIVE_LOW): cv.boolean,
-                vol.Optional("invert_logic"): cv.boolean, # backwards compatibility for now
+                vol.Optional(CONF_INVERT_LOGIC): cv.boolean, # backwards compatibility for now
                 vol.Optional(CONF_BIAS, default=DEFAULT_BIAS): vol.In(BIAS.keys()),
-                vol.Optional(CONF_DRIVE, default=DEFAULT_DRIVE): vol.In(DRIVE.keys()) 
+                vol.Optional(CONF_DRIVE, default=DEFAULT_DRIVE): vol.In(DRIVE.keys()), 
+                vol.Optional(CONF_PERSISTENT, default=DEFAULT_PERSISTENT): cv.boolean,
             }]
         )
     })
@@ -52,17 +58,31 @@ async def async_setup_platform(
 
     switches = []
     for switch in config.get(CONF_SWITCHES):
-        switches.append(
-            GPIODSwitch(
-                hub,
-                switch[CONF_NAME],
-                switch[CONF_PORT],
-                switch.get(CONF_UNIQUE_ID) or f"{DOMAIN}_{switch[CONF_PORT]}_{switch[CONF_NAME].lower().replace(' ', '_')}",
-                switch.get(CONF_ACTIVE_LOW) or switch.get("invert_logic") or DEFAULT_ACTIVE_LOW,
-                switch.get(CONF_BIAS),
-                switch.get(CONF_DRIVE)
+        if switch[CONF_PERSISTENT]:
+            switches.append(
+                PersistentRPiGPIOSwitch(
+                    hub,
+                    switch[CONF_NAME],
+                    switch[CONF_PORT],
+                    switch.get(CONF_UNIQUE_ID) or f"{DOMAIN}_{switch[CONF_PORT]}_{switch[CONF_NAME].lower().replace(' ', '_')}",
+                    switch.get(CONF_ACTIVE_LOW) or switch.get("invert_logic") or DEFAULT_ACTIVE_LOW,
+                    switch.get(CONF_BIAS),
+                    switch.get(CONF_DRIVE)
+                )
             )
-        )
+        else:
+            switches.append(
+                GPIODSwitch(
+                    hub,
+                    switch[CONF_NAME],
+                    switch[CONF_PORT],
+                    switch.get(CONF_UNIQUE_ID) or f"{DOMAIN}_{switch[CONF_PORT]}_{switch[CONF_NAME].lower().replace(' ', '_')}",
+                    switch.get(CONF_ACTIVE_LOW) or switch.get("invert_logic") or DEFAULT_ACTIVE_LOW,
+                    switch.get(CONF_BIAS),
+                    switch.get(CONF_DRIVE)
+                )
+            )
+
 
     async_add_entities(switches)
 
@@ -83,16 +103,31 @@ class GPIODSwitch(SwitchEntity):
         self._drive_mode = drive
         hub.add_switch(self, port, active_low, bias, drive)
 
-    def turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs: Any) -> None:
         self._hub.turn_on(self._port)
         self.is_on = True
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
-    def turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs: Any) -> None:
         self._hub.turn_off(self._port)
         self.is_on = False
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     def update(self):
         self.is_on = self._hub.update(self._port)
         self.schedule_update_ha_state(False)
+
+
+class PersistentRPiGPIOSwitch(GPIODSwitch, RestoreEntity):
+    async def async_added_to_hass(self) -> None:
+        """Call when the switch is added to hass."""
+        await super().async_added_to_hass()
+        state = await self.async_get_last_state()
+        _LOGGER.debug(f"recovering state: {state}")
+        if not state:
+            return
+        self.is_on = True if state.state == STATE_ON else False
+        if self.is_on:
+            await self.async_turn_on()
+        else:
+            await self.async_turn_off()


### PR DESCRIPTION
Add new GPIO switch class - PersistentRPiGPIOSwitch which will restore the switch state after Home Assistant restart.
As part of the change move the core switch to use async functions

This is based on my work in the the original branch: https://github.com/thecode/ha-rpi_gpio/pull/266